### PR TITLE
Update regex crate to fix RUSTSEC-2022-0013

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,18 +534,18 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "ryu"


### PR DESCRIPTION
See <https://rustsec.org/advisories/RUSTSEC-2022-0013> for more information on the vulnerability.

There are even newer versions of `regex` than the one used in this commit, but they would not compile with rustc 1.56.0 which seems to be the current MSRV for this project.