### PR TITLE
Update chrono crate to fix RUSTSEC-2020-0159

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,15 +78,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
 dependencies = [
- "libc",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
  "time",
+ "wasm-bindgen",
  "winapi",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 libwhen = { version = "0.4.0", path = "../libwhen" }
 anyhow = "1.0.51"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "0.4.20", features = ["serde"] }
 chrono-tz = "0.6.1"
 clap = { version = "3.0.0-rc.0", features = ["color", "derive", "cargo", "wrap_help"] }
 console = "0.15.0"

--- a/libwhen/Cargo.toml
+++ b/libwhen/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 rust-version = "1.56.0"
 
 [dependencies]
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "0.4.20", features = ["serde"] }
 chrono-humanize = "0.2.1"
 chrono-tz = "0.6.1"
 localzone = "0.2.0"

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -15,7 +15,7 @@ wasm-bindgen = "0.2.63"
 console_error_panic_hook = { version = "0.1.6", optional = true }
 wee_alloc = { version = "0.4.5", optional = true }
 libwhen = { path = "../libwhen" }
-chrono = { version = "0.4.19", features = ["wasmbind", "js-sys"] }
+chrono = { version = "0.4.20", features = ["wasmbind", "js-sys"] }
 serde_json = "1.0.72"
 serde = { version = "1.0.131", features = ["derive"] }
 


### PR DESCRIPTION
See <https://rustsec.org/advisories/RUSTSEC-2020-0159> for more information on the vulnerability, a potential segmenatation fault in `localtime_r` invocations.

There are even newer versions of `chrono` than the one used in this commit, but they would either pull in more dependencies or they would not compile with rustc 1.56.0 which seems to be the current MSRV for this project.